### PR TITLE
Fix macOS OpenSSL with a workaround

### DIFF
--- a/macos/install.ps1
+++ b/macos/install.ps1
@@ -4,3 +4,8 @@ Set-StrictMode -Version Latest
 Write-Output 'Installing gperf from brew'
 brew install gperf
 if (!$?) { throw 'Cannot install gperf from brew' }
+
+# https://github.com/actions/virtual-environments/issues/4195
+Write-Output 'Setting up an OpenSSL symlink for CMake.'
+sh -c 'ln -sf $(brew --cellar openssl@1.1)/1.1* /usr/local/opt/openssl'
+if (!$?) { throw 'Cannot set up an OpenSSL symlink.' }


### PR DESCRIPTION
A day ago, this started failing for our macOS builds. See https://github.com/actions/virtual-environments/issues/4195.

The workaround taken from [this commit](https://github.com/actions/virtual-environments/commit/4119a5acc83571fffef448ba0edd385aa5c34a13).