### PR TITLE
(#76) Windows: disable Readline search

### DIFF
--- a/windows/build.ps1
+++ b/windows/build.ps1
@@ -21,6 +21,7 @@ try {
     )
     $cmakeArguments = @(
         "-DCMAKE_TOOLCHAIN_FILE=$VcpkgToolchain"
+        '-DCMAKE_DISABLE_FIND_PACKAGE_Readline=TRUE' # workaround for #76
         '..'
     )
     $cmakeBuildArguments = @(


### PR DESCRIPTION
Readline has recently started to be found in `C:/Strawberry/c/include`, but the build can't use that version for some reason.

As we weren't using Readline earlier, I think it's better to explicitly disable it for now.

Closes #76.