### PR TITLE
CI: run periodic builds on Monday

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
     branches:
     - master
   schedule:
-  - cron: 0 0 * * 6
+  - cron: 0 0 * * 1
   workflow_dispatch: 
 jobs:
   build-linux-x86-64:

--- a/github-actions.fsx
+++ b/github-actions.fsx
@@ -172,7 +172,7 @@ let workflows = [
         onPushTo mainBranch
         onPushTags "v*"
         onPullRequestTo mainBranch
-        onSchedule(day = DayOfWeek.Saturday)
+        onSchedule(day = DayOfWeek.Monday)
         onWorkflowDispatch
 
         Workflows.BuildJob(


### PR DESCRIPTION
The idea is to build once on Monday to fill the weekly cache and reuse it during the week, if any builds arrive.